### PR TITLE
Topic/common start logic

### DIFF
--- a/common/startService.js
+++ b/common/startService.js
@@ -15,8 +15,8 @@
     const sslCredentials = getSslCredentials();
     if (sslCredentials) {
       const securePort = parseInt(config[type].securePort);
+      setupSecureRedirect(app);
       https.createServer(sslCredentials, app).listen(securePort);
-
     }
     const port = parseInt(config[type].port);
     http.createServer(app).listen(port);
@@ -50,10 +50,7 @@
       key: readCredential(key)
     };
 
-    return credentials.ca
-        && credentials.cert
-        && credentials.key
-        && credentials;
+    return credentials.ca && credentials.cert && credentials.key && credentials;
 
     function readCredential(path) {
       try {

--- a/common/startService.js
+++ b/common/startService.js
@@ -1,0 +1,77 @@
+(function () {
+  'use strict';
+
+  const fs = require('fs');
+  const path = require('path');
+  const http = require('http');
+  const https = require('https');
+  const production = process.env.NODE_ENV === 'production';
+  const config = production ? require('../config/production.json').hostnames
+                            : require('../config/local.json').hostnames;
+
+  module.exports = function startService(app, type) {
+    setupAcmeChallengeRoute(app);
+
+    const sslCredentials = getSslCredentials();
+    if (sslCredentials) {
+      const securePort = parseInt(config[type].securePort);
+      https.createServer(sslCredentials, app).listen(securePort);
+
+    }
+    const port = parseInt(config[type].port);
+    http.createServer(app).listen(port);
+  };
+
+  function setupAcmeChallengeRoute(app) {
+    const wellknownAcmeDir = '/.well-known/acme-challenge/';
+    const acmeChallengeEndpoint = path.join(wellknownAcmeDir, ':hash');
+
+    app.get(acmeChallengeEndpoint, function (req, res) {
+      const challengePath = path.join(wellknownAcmeDir, req.params.hash);
+      fs.readFile(challengePath, function (err, data) {
+        if (err || !data) {
+          res.sendStatus(500);
+          return;
+        }
+        res.send(data.toString());
+      });
+    });
+  }
+
+  function getSslCredentials() {
+    const certPath = 'certs';
+    const ca = path.join(__dirname, certPath, 'chain.pem');
+    const key = path.join(__dirname, certPath, 'privkey.pem');
+    const cert = path.join(__dirname, certPath, 'cert.pem');
+
+    const credentials = {
+      ca: readCredential(ca),
+      cert: readCredential(cert),
+      key: readCredential(key)
+    };
+
+    return credentials.ca
+        && credentials.cert
+        && credentials.key
+        && credentials;
+
+    function readCredential(path) {
+      try {
+        return fs.readFileSync(path).toString();
+      } catch (e) {
+        return undefined;
+      }
+    }
+  }
+
+  function setupSecureRedirect(app) {
+    app.all('*', function (req, res, next) {
+      if (!req.secure) {
+        res.redirect('https://' + req.headers.host + req.url);
+      }
+      else {
+        next();
+      }
+    });
+  }
+})();

--- a/config/local.json
+++ b/config/local.json
@@ -2,29 +2,35 @@
     "hostnames": {
         "mun": {
             "domain": "localhost",
-            "port": "3500"
+            "port": "3500",
+            "securePort": "3501"
         },
         "re": {
             "domain": "localhost",
-            "port": "3550"
+            "port": "3550",
+            "securePort": "3551"
         },
         "insinc": {
             "domain": "localhost",
-            "port": "53045"
+            "port": "53045",
+            "securePort": "53046"
         },
         "emp": {
             "domain": "localhost",
             "port": "1337",
+            "securePort": "1338",
             "accessTokenName": "CSCI4145_EMP_ACCESS_TOKEN",
             "mongoDbUrl": "mongodb://broderick:5m3nve0bj2@ds121980.mlab.com:21980/emp-db-csci4145-proj"
         },
         "log": {
             "domain": "localhost",
-            "port": "3000"
+            "port": "3000",
+            "securePort": "3001"
         },
         "mbr": {
             "domain": "localhost",
-            "port": "3100"
+            "port": "3100",
+            "securePort": "3101"
         }
     }
 }

--- a/config/local.json
+++ b/config/local.json
@@ -19,8 +19,7 @@
             "domain": "localhost",
             "port": "1337",
             "securePort": "1338",
-            "accessTokenName": "CSCI4145_EMP_ACCESS_TOKEN",
-            "mongoDbUrl": "mongodb://broderick:5m3nve0bj2@ds121980.mlab.com:21980/emp-db-csci4145-proj"
+            "accessTokenName": "CSCI4145_EMP_ACCESS_TOKEN"
         },
         "log": {
             "domain": "localhost",

--- a/config/prod.json
+++ b/config/prod.json
@@ -2,29 +2,35 @@
     "hostnames": {
         "mun": {
             "domain": "localhost",
-            "port": "3500"
+            "port": "3500",
+            "securePort": "3501"
         },
         "re": {
             "domain": "localhost",
-            "port": "3550"
+            "port": "3550",
+            "securePort": "3551"
         },
         "insinc": {
             "domain": "localhost",
-            "port": "53045"
+            "port": "53045",
+            "securePort": "53045"
         },
         "emp": {
             "domain": "localhost",
             "port": "1337",
+            "securePort": "1338",
             "accessTokenName": "CSCI4145_EMP_ACCESS_TOKEN",
             "mongoDbUrl": "mongodb://broderick:5m3nve0bj2@ds121980.mlab.com:21980/emp-db-csci4145-proj"
         },
         "log": {
             "domain": "localhost",
-            "port": "3000"
+            "port": "3000",
+            "securePort": "3001"
         },
         "mbr": {
             "domain": "localhost",
-            "port": "3100"
+            "port": "3100",
+            "securePort": "3100"
         }
     }
 }

--- a/emp/app.js
+++ b/emp/app.js
@@ -7,19 +7,19 @@
 
   const express = require('express');
   const path = require('path');
-  const http = require('http');
   const dbConn = require('./shared/dbConn.js');
   const log = require('../common/common.js').logInfo;
+  const startService = require('../common/startService.js');
 
   const app = express();
 
   setupMiddleware(app);
   setAppSecret(app);
-  injectAuthoirzationTokenParser(app);
+  injectAuthTokenParser(app);
   setViewPath(app);
   loadRoutes(app, dbConn);
 
-  http.createServer(app).listen(config.port);
+  startService(app, 'emp');
 
   /* Utility methods */
 
@@ -41,7 +41,7 @@
     app.set('secret', appSecret);
   }
 
-  function injectAuthoirzationTokenParser(app) {
+  function injectAuthTokenParser(app) {
     const jwt = require('jsonwebtoken');
 
     app.use(function (req, res, next) {


### PR DESCRIPTION
This should get us going in the right direction for securing everything over trusted SSL. (Green padlock HYPE!)

Essentially, I've implemented common startup functionality that should accomplish some necessary things for every service towards that goal:

- Setup an ACME challenge route that will be needed when we try to obtain SSL certs for each service
- Load SSL certificates on startup and opens a connection over SSL whenever certificates are found in a folder named ./certs
- Redirect all incoming requests over http to https whenever the server can accommodate SSL connections (alternately, we could just only open SSL connections).